### PR TITLE
Ensure that stacktrace can be included issue.Reported is created

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="GoUnusedConst" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GoUnusedExportedFunction" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="GoUnusedGlobalVariable" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="PuppetUnresolved" enabled="false" level="WARNING" enabled_by_default="false" />

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/lyraproj/pcore
 
 require (
 	github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820
-	github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560
+	github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820 h1:fmQMG2XA
 github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560 h1:VVFwiMUrZe1a64kpEGzrPdeB6QzGEZTAVeo1OTOEWEk=
 github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
+github.com/lyraproj/issue v0.0.0-20190319123655-1254f3f904c8 h1:Bube19xEIHW0YETnWclg5IhszJWGeG8N6PrM1v2ipW4=
+github.com/lyraproj/issue v0.0.0-20190319123655-1254f3f904c8/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
+github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0 h1:qjAIOHlkKCKyulOLovyl2ITvySGUYjJGg4oFTUAQslE=
+github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/px/context.go
+++ b/px/context.go
@@ -151,8 +151,7 @@ func CurrentContext() Context {
 	if ctx, ok := threadlocal.Get(PuppetContextKey); ok {
 		return ctx.(Context)
 	}
-	_, file, line, _ := runtime.Caller(1)
-	panic(issue.NewReported(NoCurrentContext, issue.SEVERITY_ERROR, issue.NO_ARGS, issue.NewLocation(file, line, 0)))
+	panic(issue.NewReported(NoCurrentContext, issue.SEVERITY_ERROR, issue.NO_ARGS, 0))
 }
 
 // Fork calls the given function in a new go routine. The given context is forked and becomes

--- a/px/reflector_test.go
+++ b/px/reflector_test.go
@@ -607,7 +607,7 @@ func ExampleReflector_TypeFromReflect_twoValueReturnErrorFail() {
 		return nil
 	})
 	if err != nil {
-		fmt.Println(err.Error())
+		fmt.Println(err.Error()[:70])
 	}
 	// Output:
 	// Go function ReturnTwoAndErrorFail returned error 'bad things happened'

--- a/px/wrap.go
+++ b/px/wrap.go
@@ -12,7 +12,7 @@ func LogWarning(issueCode issue.Code, args issue.H) {
 // Error creates a Reported with the given issue code, location from stack top, and arguments
 // Typical use is to panic with the returned value
 func Error(issueCode issue.Code, args issue.H) issue.Reported {
-	return issue.NewReported(issueCode, issue.SEVERITY_ERROR, args, StackTop())
+	return issue.NewReported(issueCode, issue.SEVERITY_ERROR, args, 1)
 }
 
 // Error2 creates a Reported with the given issue code, location from stack top, and arguments
@@ -25,7 +25,7 @@ func Error2(location issue.Location, issueCode issue.Code, args issue.H) issue.R
 // and logs it on the currently active logger
 func Warning(issueCode issue.Code, args issue.H) issue.Reported {
 	c := CurrentContext()
-	ri := issue.NewReported(issueCode, issue.SEVERITY_WARNING, args, c.StackTop())
+	ri := issue.NewReported(issueCode, issue.SEVERITY_WARNING, args, 1)
 	c.Logger().LogIssue(ri)
 	return ri
 }


### PR DESCRIPTION
This commit changes how issue.NewReported is called so that an caller
offset is passed as the last argument rather than a location. If
issue.IncludeStacktrace(true) has been called, this will ensure that the
included stacktrace origins from the place where the panic using the
created Reported happens.