### PR TITLE
Make Object constructor accept nested objects in the form of a Hash

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,13 +4,6 @@ github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820 h1:fmQMG2XAvAhT5gt9PxXhY3+2iHJPBM1Y073MuNTZShM=
 github.com/lyraproj/data-protobuf v0.0.0-20181217135414-3d508204b820/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
-github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560 h1:VVFwiMUrZe1a64kpEGzrPdeB6QzGEZTAVeo1OTOEWEk=
-github.com/lyraproj/issue v0.0.0-20190213110846-64f0e861a560/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/issue v0.0.0-20190319123655-1254f3f904c8 h1:Bube19xEIHW0YETnWclg5IhszJWGeG8N6PrM1v2ipW4=
-github.com/lyraproj/issue v0.0.0-20190319123655-1254f3f904c8/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0 h1:qjAIOHlkKCKyulOLovyl2ITvySGUYjJGg4oFTUAQslE=
-github.com/lyraproj/issue v0.0.0-20190319130620-4de77398eaa0/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
-github.com/lyraproj/issue v0.0.0-20190319142512-87bdca048c6e h1:sUMHEmbU4Hwj1BXtYyU/VzFxgD3wv8KLMKfljGOP6RY=
 github.com/lyraproj/issue v0.0.0-20190319145359-029b4266d45b h1:niKVq5VjkwpgwUqXmr7jL+WuoWXbqN2UvkM/grgj4gk=
 github.com/lyraproj/issue v0.0.0-20190319145359-029b4266d45b/go.mod h1:F3Zu9SjR6zROUIVdxgxuX0/Mi4npwgDRalQCNzCyzU0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=

--- a/px/reflector_test.go
+++ b/px/reflector_test.go
@@ -1237,7 +1237,7 @@ func ExampleReflector_TypeFromReflect_nestedSliceToInterface() {
 	pcore.Do(func(c px.Context) {
 		x := c.Reflector().TypeFromReflect(`X`, nil, reflect.TypeOf(&nestedInterface{}))
 		px.AddTypes(c, x)
-		v := types.CoerceTo(c, "test", true, x, px.Wrap(c, map[string][]map[string][]string{`a`: {{`v`: {`a`, `b`}}}}))
+		v := types.CoerceTo(c, "test", x, px.Wrap(c, map[string][]map[string][]string{`a`: {{`v`: {`a`, `b`}}}}))
 		v.ToString(os.Stdout, px.Pretty, nil)
 		fmt.Println()
 	})

--- a/px/types.go
+++ b/px/types.go
@@ -280,16 +280,24 @@ var DefaultFor func(t Type) Type
 
 func AssertType(pfx interface{}, expected, actual Type) Type {
 	if !IsAssignable(expected, actual) {
-		panic(Error(TypeMismatch, issue.H{`detail`: DescribeMismatch(getPrefix(pfx), expected, actual)}))
+		panic(TypeMismatchError(pfx, expected, actual))
 	}
 	return actual
 }
 
 func AssertInstance(pfx interface{}, expected Type, value Value) Value {
 	if !IsInstance(expected, value) {
-		panic(Error(TypeMismatch, issue.H{`detail`: DescribeMismatch(getPrefix(pfx), expected, DetailedValueType(value))}))
+		panic(MismatchError(pfx, expected, value))
 	}
 	return value
+}
+
+func MismatchError(pfx interface{}, expected Type, value Value) issue.Reported {
+	return Error(TypeMismatch, issue.H{`detail`: DescribeMismatch(getPrefix(pfx), expected, DetailedValueType(value))})
+}
+
+func TypeMismatchError(pfx interface{}, expected Type, actual Type) issue.Reported {
+	return Error(TypeMismatch, issue.H{`detail`: DescribeMismatch(getPrefix(pfx), expected, actual)})
 }
 
 // New creates a new instance of type t

--- a/types/coerce.go
+++ b/types/coerce.go
@@ -1,0 +1,174 @@
+package types
+
+import (
+	"strings"
+
+	"github.com/lyraproj/pcore/px"
+)
+
+// CoerceTo will deep coerce the given value into an instance of the given type t. The coercion will
+// recurse down into hashes, arrays, and objects and take key, value, and attribute types into account.
+//
+// The label is used in potential type assertion errors. It should indicate what it is that is being
+// coerced.
+func CoerceTo(c px.Context, label string, typ px.Type, value px.Value) (result px.Value) {
+	return coerceTo(c, []string{label}, typ, value)
+}
+
+type path []string
+
+func (p path) with(n string) path {
+	np := make(path, len(p)+1)
+	copy(np, p)
+	np[len(p)] = n
+	return np
+}
+
+// CanCoerce responds true iv the given value can be coerced into an instance of the given type.
+func CanCoerce(typ px.Type, value px.Value) bool {
+	if typ.IsInstance(value, nil) {
+		return true
+	}
+
+	if opt, ok := typ.(*OptionalType); ok {
+		typ = opt.ContainedType()
+	}
+
+	switch t := typ.(type) {
+	case *ArrayType:
+		et := t.ElementType()
+		if oa, ok := value.(*Array); ok {
+			return oa.All(func(e px.Value) bool { return CanCoerce(et, e) })
+		}
+		return CanCoerce(et, value)
+	case *HashType:
+		kt := t.KeyType()
+		vt := t.ValueType()
+		if oh, ok := value.(*Hash); ok {
+			return oh.All(func(v px.Value) bool {
+				e := v.(px.MapEntry)
+				if CanCoerce(kt, e.Key()) {
+					return CanCoerce(vt, e.Value())
+				}
+				return false
+			})
+		}
+		return false
+	case *StructType:
+		hm := t.HashedMembers()
+		if oh, ok := value.(*Hash); ok {
+			return oh.All(func(v px.Value) bool {
+				e := v.(px.MapEntry)
+				var s px.StringValue
+				if s, ok = e.Key().(px.StringValue); ok {
+					var se *StructElement
+					if se, ok = hm[s.String()]; ok {
+						return CanCoerce(se.Value(), e.Value())
+					}
+				}
+				return false
+			})
+		}
+		return false
+	case px.ObjectType:
+		ai := t.AttributesInfo()
+		switch o := value.(type) {
+		case *Array:
+			for i, ca := range ai.Attributes() {
+				if i >= o.Len() {
+					return i <= ai.RequiredCount()
+				}
+				if !CanCoerce(ca.Type(), o.At(i)) {
+					return false
+				}
+			}
+		case *Hash:
+			for _, ca := range ai.Attributes() {
+				e, ok := o.GetEntry(ca.Name())
+				if !ok {
+					if !ca.HasValue() {
+						return false
+					}
+				} else if !CanCoerce(ca.Type(), e.Value()) {
+					return false
+				}
+			}
+		default:
+			return false
+		}
+		return true
+	case *InitType:
+		// Should have answered true to IsInstance above
+		return false
+	}
+	return NewInitType(typ, emptyArray).IsInstance(value, nil)
+}
+
+func coerceTo(c px.Context, path path, typ px.Type, value px.Value) px.Value {
+	if typ.IsInstance(value, nil) {
+		return value
+	}
+
+	if opt, ok := typ.(*OptionalType); ok {
+		typ = opt.ContainedType()
+	}
+
+	labelFunc := func() string { return strings.Join(path, `/`) }
+
+	switch t := typ.(type) {
+	case *ArrayType:
+		et := t.ElementType()
+		ep := path.with(`[]`)
+		if oa, ok := value.(*Array); ok {
+			value = oa.Map(func(e px.Value) px.Value { return coerceTo(c, ep, et, e) })
+			if t.Size().IsInstance3(value.(*Array).Len()) {
+				return value
+			}
+		}
+		panic(px.MismatchError(labelFunc, t, value))
+	case *HashType:
+		kt := t.KeyType()
+		vt := t.ValueType()
+		kp := path.with(`key`)
+		if oh, ok := value.(*Hash); ok {
+			value = oh.MapEntries(func(e px.MapEntry) px.MapEntry {
+				kv := coerceTo(c, kp, kt, e.Key())
+				return WrapHashEntry(kv, coerceTo(c, path.with(kv.String()), vt, e.Value()))
+			})
+			if !t.Size().IsInstance3(value.(*Hash).Len()) {
+				panic(px.MismatchError(labelFunc, t, value))
+			}
+			return value
+		}
+		panic(px.MismatchError(labelFunc, t, value))
+	case *StructType:
+		hm := t.HashedMembers()
+		if oh, ok := value.(*Hash); ok {
+			value = oh.MapEntries(func(e px.MapEntry) px.MapEntry {
+				var s px.StringValue
+				if s, ok = e.Key().(px.StringValue); ok {
+					var se *StructElement
+					if se, ok = hm[s.String()]; ok {
+						return WrapHashEntry(s, coerceTo(c, path.with(s.String()), se.Value(), e.Value()))
+					}
+				}
+				return e
+			})
+			return px.AssertInstance(labelFunc, t, value)
+		}
+		panic(px.MismatchError(labelFunc, t, value))
+	case px.ObjectType:
+		ai := t.AttributesInfo()
+		if oh, ok := value.(*Hash); ok {
+			el := make([]*HashEntry, 0, oh.Len())
+			for _, ca := range ai.Attributes() {
+				if e, ok := oh.GetEntry(ca.Name()); ok {
+					el = append(el, WrapHashEntry(e.Key(), coerceTo(c, []string{ca.Label()}, ca.Type(), e.Value())))
+				}
+			}
+			return newInstance(c, t, oh.Merge(WrapHash(el)))
+		}
+		panic(px.MismatchError(labelFunc, t, value))
+	}
+	return newInstance(c, typ, value)
+}

--- a/types/typeset.go
+++ b/types/typeset.go
@@ -479,7 +479,7 @@ func (t *typeSet) basicTypeToString(b io.Writer, f px.Format, s px.FormatContext
 		utils.WriteString(b, name)
 		return
 	}
-	s = s.WithProperties(map[string]string{`typeSet`: t.Name()})
+	s = s.WithProperties(map[string]string{`typeSet`: t.Name(), `typeSetParent`: `true`})
 
 	utils.WriteString(b, `TypeSet[{`)
 	indent1 := s.Indentation()


### PR DESCRIPTION
This commit ensures that the Object constructor will allow two forms
for a nested Object. The first form is an instance of that Object (like
before) and the second form is a Hash that conforms to the Init type
of that object.

This functionality was previously present in the YAML parser. Placing
it in the Object itself makes i generic and also makes it easy to
create nested instances that contain anonymous types.