### PR TITLE
Don't include nil values from Go struct when creating init hash

### DIFF
--- a/types/objecttype.go
+++ b/types/objecttype.go
@@ -945,7 +945,15 @@ func (t *objectType) appendAttributeValues(c px.Context, entries []*HashEntry, s
 		if field.Anonymous && i == 0 && t.parent != nil {
 			entries = t.resolvedParent().appendAttributeValues(c, entries, &sf)
 		} else {
-			entries = append(entries, WrapHashEntry2(FieldName(&field), wrap(c, sf)))
+			if sf.IsValid() {
+				switch sf.Kind() {
+				case reflect.Slice, reflect.Map, reflect.Interface, reflect.Ptr:
+					if sf.IsNil() {
+						continue
+					}
+				}
+				entries = append(entries, WrapHashEntry2(FieldName(&field), wrap(c, sf)))
+			}
 		}
 	}
 	return entries


### PR DESCRIPTION
When the initialization hash used when creating an Object instance stems
from a Go struct, it must not include those fields that have a nil
value. The reason for this is that an Object might well declare an
attribute of Boolean type with a default value of false or true. Such
an attribute will require that any value assigned to this attribute must
be of type Boolean. It is not acceptable to assign Undef. To include an
explicit undef value in a initialization hash implies such an illegal
assigment. Such entries must therefore not be included at all. The
Object constructor will then fall back to the default value.