### PR TITLE
Make it possible to use Hash and Array as keys in a Hash

### DIFF
--- a/px/issues.go
+++ b/px/issues.go
@@ -35,6 +35,7 @@ const (
 	InstanceDoesNotRespond                = `PCORE_INSTANCE_DOES_NOT_RESPOND`
 	ImpossibleOptional                    = `PCORE_IMPOSSIBLE_OPTIONAL`
 	InvalidCharactersInName               = `PCORE_INVALID_CHARACTERS_IN_NAME`
+	InvalidHashKey                        = `PCORE_INVALID_MAP_KEY`
 	InvalidJson                           = `PCORE_INVALID_JSON`
 	InvalidRegexp                         = `PCORE_INVALID_REGEXP`
 	InvalidSourceForGet                   = `PCORE_INVALID_SOURCE_FOR_GET`
@@ -173,6 +174,8 @@ func init() {
 	issue.Hard(InvalidCharactersInName, `Name '%{name} contains invalid characters. Must start with letter and only contain letters, digits, and underscore'`)
 
 	issue.Hard(InvalidJson, `Unable to parse JSON from '%{path}': %{detail}`)
+
+	issue.Hard2(InvalidHashKey, `%{type} values cannot be used as a keys in a Hash`, issue.HF{`type`: issue.UcAnOrA})
 
 	issue.Hard(InvalidRegexp, `Cannot compile regular expression '%{pattern}': %{detail}`)
 

--- a/types/arraytype.go
+++ b/types/arraytype.go
@@ -570,6 +570,14 @@ func (av *Array) String() string {
 	return px.ToString2(av, None)
 }
 
+func (av *Array) ToKey(b *bytes.Buffer) {
+	b.WriteByte(0)
+	b.WriteByte(HkArray)
+	for _, e := range av.elements {
+		appendKey(b, e)
+	}
+}
+
 func (av *Array) ToString(b io.Writer, s px.FormatContext, g px.RDetect) {
 	av.ToString2(b, s, px.GetFormat(s.FormatMap(), av.PType()), '[', g)
 }

--- a/types/hashtype.go
+++ b/types/hashtype.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"math"
@@ -569,6 +570,13 @@ func (he *HashEntry) Value() px.Value {
 
 func (he *HashEntry) String() string {
 	return px.ToString2(he, None)
+}
+
+func (he *HashEntry) ToKey(b *bytes.Buffer) {
+	b.WriteByte(0)
+	b.WriteByte(HkEntry)
+	appendKey(b, he.key)
+	appendKey(b, he.value)
 }
 
 func (he *HashEntry) ToString(b io.Writer, s px.FormatContext, g px.RDetect) {
@@ -1167,6 +1175,14 @@ func (hv *Hash) Sort(comparator px.Comparator) px.List {
 
 func (hv *Hash) String() string {
 	return px.ToString2(hv, None)
+}
+
+func (hv *Hash) ToKey(b *bytes.Buffer) {
+	b.WriteByte(0)
+	b.WriteByte(HkHash)
+	for _, e := range hv.entries {
+		e.ToKey(b)
+	}
 }
 
 func (hv *Hash) ToString(b io.Writer, s px.FormatContext, g px.RDetect) {

--- a/types/types.go
+++ b/types/types.go
@@ -22,10 +22,13 @@ import (
 const (
 	NoString = "\x00"
 
+	HkArray        = byte('A')
 	HkBinary       = byte('B')
 	HkBoolean      = byte('b')
 	HkDefault      = byte('d')
+	HkEntry        = byte('E')
 	HkFloat        = byte('f')
+	HkHash         = byte('H')
 	HkInteger      = byte('i')
 	HkRegexp       = byte('r')
 	HkTimespan     = byte('D')
@@ -564,7 +567,7 @@ func appendKey(b *bytes.Buffer, v px.Value) {
 	} else if hk, ok := v.(px.HashKeyValue); ok {
 		b.Write([]byte(hk.ToKey()))
 	} else {
-		panic(illegalArgumentType(`ToKey`, 0, `value used as hash key`, v))
+		panic(px.Error(px.InvalidHashKey, issue.H{`type`: v.PType()}))
 	}
 }
 


### PR DESCRIPTION
Prior to this commit, an attempt to use an array as a hash key would
fail with a somewhat cryptic error stating

"invalid argument type for function ToKey, argument 0. expected 'value
 used as hash key', got Tuple[<element types>]".

This commit makes it possible to use both Array and Hash values as keys
in a Hash and corrects the error messages for types that cannot
be used.

Closes lyraproj/lyra#236