### PR TITLE
Add reflection of type interface{} to pcore type Any

### DIFF
--- a/px/reflector_test.go
+++ b/px/reflector_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/lyraproj/pcore/pcore"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
@@ -120,6 +122,44 @@ func TestReflectorAndImplRepo(t *testing.T) {
 		if tss != exp {
 			t.Errorf("Expected %s, got %s\n", exp, tss)
 		}
+	})
+}
+
+func TestReflector_reflectValue(t *testing.T) {
+	pcore.Do(func(c px.Context) {
+		oi := c.Reflector().InitializerFromTagged(`A`, nil, px.NewAnnotatedType(reflect.TypeOf(struct{ A px.Value }{}), nil, nil))
+		v, ok := oi.Get4(`attributes`)
+		require.True(t, ok)
+		require.IsType(t, px.EmptyMap, v)
+		v, ok = v.(px.OrderedMap).Get4(`a`)
+		require.True(t, ok)
+		require.IsType(t, px.EmptyMap, v)
+		x, ok := v.(px.OrderedMap).Get4(`type`)
+		require.True(t, ok)
+		require.Equal(t, types.DefaultAnyType(), x)
+		_, ok = v.(px.OrderedMap).Get4(`value`)
+		require.False(t, ok)
+		_, ok = v.(px.OrderedMap).Get4(`has_value`)
+		require.False(t, ok)
+	})
+}
+
+func TestReflector_reflectGoInterface(t *testing.T) {
+	pcore.Do(func(c px.Context) {
+		oi := c.Reflector().InitializerFromTagged(`A`, nil, px.NewAnnotatedType(reflect.TypeOf(struct{ A interface{} }{}), nil, nil))
+		v, ok := oi.Get4(`attributes`)
+		require.True(t, ok)
+		require.IsType(t, px.EmptyMap, v)
+		v, ok = v.(px.OrderedMap).Get4(`a`)
+		require.True(t, ok)
+		require.IsType(t, px.EmptyMap, v)
+		x, ok := v.(px.OrderedMap).Get4(`type`)
+		require.True(t, ok)
+		require.Equal(t, types.DefaultAnyType(), x)
+		_, ok = v.(px.OrderedMap).Get4(`value`)
+		require.False(t, ok)
+		_, ok = v.(px.OrderedMap).Get4(`has_value`)
+		require.False(t, ok)
 	})
 }
 

--- a/types/reflector.go
+++ b/types/reflector.go
@@ -366,7 +366,7 @@ func (r *reflector) ReflectFieldTags(f *reflect.StructField, fh px.OrderedMap, o
 		}
 	}
 
-	optional := typ.IsInstance(px.Undef, nil)
+	_, optional := typ.(*OptionalType)
 	if optional {
 		if val == nil {
 			// If no value is declared and the type is declared as optional, then

--- a/types/types.go
+++ b/types/types.go
@@ -824,6 +824,13 @@ func wrapReflectedType(c px.Context, vt reflect.Type) (pt px.Type, err error) {
 		if t, err = wrapReflectedType(c, vt.Elem()); err == nil {
 			pt = NewOptionalType(t)
 		}
+	case reflect.Interface:
+		vn := vt.Name()
+		if vn == `` {
+			pt = DefaultAnyType()
+		} else {
+			err = px.Error(px.UnreflectableType, issue.H{`type`: vn})
+		}
 	default:
 		pt, ok = primitivePTypes[vt.Kind()]
 		if !ok {


### PR DESCRIPTION
Prior to this commit, it was not possible to reflect fields of type
interface{} into a pcore attribute. Now a interface{} field will be
reflected like a px.Value field and be of type Any.