### PR TITLE
Switch to use gopkg.in/yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 // indirect
-	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )

--- a/go.sum
+++ b/go.sum
@@ -17,5 +17,5 @@ golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6 h1:bjcUS9ztw9kFmmIxJInhon/0
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae h1:ehhBuCxzgQEGk38YjhFv/97fMIc2JGHZAhAWMmEjmu0=
+gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/yaml/unmarshal.go
+++ b/yaml/unmarshal.go
@@ -1,37 +1,71 @@
 package yaml
 
 import (
+	"time"
+
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
 	ym "gopkg.in/yaml.v3"
 )
 
+type Value struct {
+	px.Value
+	Line   int
+	Column int
+}
+
+func (v *Value) ToKey() px.HashKey {
+	return px.ToKey(v.Value)
+}
+
+func (v *Value) Unwrap() (uv px.Value) {
+	switch x := v.Value.(type) {
+	case px.OrderedMap:
+		uv = x.MapEntries(func(e px.MapEntry) px.MapEntry {
+			return types.WrapHashEntry(
+				e.Key().(*Value).Unwrap(),
+				e.Value().(*Value).Unwrap())
+		})
+	case *types.Array:
+		uv = x.Map(func(e px.Value) px.Value {
+			return e.(*Value).Unwrap()
+		})
+	default:
+		uv = v.Value
+	}
+	return
+}
+
 func Unmarshal(c px.Context, data []byte) px.Value {
 	var ms ym.Node
 	err := ym.Unmarshal([]byte(data), &ms)
 	if err != nil {
-		var itm interface{}
-		err2 := ym.Unmarshal([]byte(data), &itm)
-		if err2 != nil {
-			panic(px.Error(px.ParseError, issue.H{`language`: `YAML`, `detail`: err.Error()}))
-		}
-		return wrapValue(c, itm)
+		panic(px.Error(px.ParseError, issue.H{`language`: `YAML`, `detail`: err.Error()}))
 	}
 	return wrapNode(c, &ms)
 }
 
-func wrapNode(c px.Context, n *ym.Node) px.Value {
+func UnmarshalWithPositions(c px.Context, data []byte) *Value {
+	var ms ym.Node
+	err := ym.Unmarshal([]byte(data), &ms)
+	if err != nil {
+		panic(px.Error(px.ParseError, issue.H{`language`: `YAML`, `detail`: err.Error()}))
+	}
+	return wrapNodeWithPosition(c, &ms)
+}
+
+func wrapNode(c px.Context, n *ym.Node) (v px.Value) {
 	switch n.Kind {
 	case ym.DocumentNode:
-		return wrapNode(c, n.Content[0])
+		v = wrapNode(c, n.Content[0])
 	case ym.SequenceNode:
 		ms := n.Content
 		es := make([]px.Value, len(ms))
 		for i, me := range ms {
 			es[i] = wrapNode(c, me)
 		}
-		return types.WrapValues(es)
+		v = types.WrapValues(es)
 	case ym.MappingNode:
 		ms := n.Content
 		top := len(ms)
@@ -39,29 +73,78 @@ func wrapNode(c px.Context, n *ym.Node) px.Value {
 		for i := 0; i < top; i += 2 {
 			es[i/2] = types.WrapHashEntry(wrapNode(c, ms[i]), wrapNode(c, ms[i+1]))
 		}
-		return types.WrapHash(es)
-	case ym.ScalarNode:
-		var v interface{}
-		err := n.Decode(&v)
+		v = types.WrapHash(es)
+	default:
+		v = wrapScalar(c, n)
+	}
+	return
+}
+
+func wrapNodeWithPosition(c px.Context, n *ym.Node) (v *Value) {
+	switch n.Kind {
+	case ym.DocumentNode:
+		v = wrapNodeWithPosition(c, n.Content[0])
+	case ym.SequenceNode:
+		ms := n.Content
+		es := make([]px.Value, len(ms))
+		for i, me := range ms {
+			es[i] = wrapNodeWithPosition(c, me)
+		}
+		v = &Value{types.WrapValues(es), n.Line, n.Column}
+	case ym.MappingNode:
+		ms := n.Content
+		top := len(ms)
+		es := make([]*types.HashEntry, top/2)
+		for i := 0; i < top; i += 2 {
+			es[i/2] = types.WrapHashEntry(wrapNodeWithPosition(c, ms[i]), wrapNodeWithPosition(c, ms[i+1]))
+		}
+		v = &Value{types.WrapHash(es), n.Line, n.Column}
+	default:
+		v = &Value{wrapScalar(c, n), n.Line, n.Column}
+	}
+	return
+}
+
+func wrapScalar(c px.Context, n *ym.Node) px.Value {
+	var v px.Value
+	switch n.Tag {
+	case `!!null`:
+		v = px.Undef
+	case `!!bool`:
+		var x bool
+		if err := n.Decode(&x); err != nil {
+			panic(err)
+		}
+		v = types.WrapBoolean(x)
+	case `!!int`:
+		var x int64
+		if err := n.Decode(&x); err != nil {
+			panic(err)
+		}
+		v = types.WrapInteger(x)
+	case `!!float`:
+		var x float64
+		if err := n.Decode(&x); err != nil {
+			panic(err)
+		}
+		v = types.WrapFloat(x)
+	case `!!timestamp`:
+		var x time.Time
+		if err := n.Decode(&x); err != nil {
+			panic(err)
+		}
+		v = types.WrapTimestamp(x)
+	case `!!str`:
+		v = types.WrapString(n.Value)
+	case `!!binary`:
+		v = types.BinaryFromString(n.Value, `%b`)
+	default:
+		var x interface{}
+		err := n.Decode(&x)
 		if err != nil {
 			panic(err)
 		}
-		return px.Wrap(c, v)
+		v = px.Wrap(c, x)
 	}
-	return px.Undef
-}
-
-func wrapValue(c px.Context, v interface{}) px.Value {
-	switch v := v.(type) {
-	case *ym.Node:
-		return wrapNode(c, v)
-	case []interface{}:
-		vs := make([]px.Value, len(v))
-		for i, y := range v {
-			vs[i] = wrapValue(c, y)
-		}
-		return types.WrapValues(vs)
-	default:
-		return px.Wrap(c, v)
-	}
+	return v
 }

--- a/yaml/unmarshal_test.go
+++ b/yaml/unmarshal_test.go
@@ -1,0 +1,26 @@
+package yaml_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lyraproj/pcore/pcore"
+	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/pcore/yaml"
+)
+
+const text = `
+foo:
+  bar: [1, 2, {hello: sub}]
+bar:
+  - 1
+  - 2
+`
+
+func TestUnmarshal(t *testing.T) {
+	pcore.Do(func(c px.Context) {
+		v := yaml.Unmarshal(c, []byte(text))
+		require.Equal(t, `{'foo' => {'bar' => [1, 2, {'hello' => 'sub'}]}, 'bar' => [1, 2]}`, v.String())
+	})
+}

--- a/yaml/unmarshal_test.go
+++ b/yaml/unmarshal_test.go
@@ -10,8 +10,7 @@ import (
 	"github.com/lyraproj/pcore/yaml"
 )
 
-const text = `
-foo:
+const text = `foo:
   bar: [1, 2, {hello: sub}]
 bar:
   - 1
@@ -22,5 +21,18 @@ func TestUnmarshal(t *testing.T) {
 	pcore.Do(func(c px.Context) {
 		v := yaml.Unmarshal(c, []byte(text))
 		require.Equal(t, `{'foo' => {'bar' => [1, 2, {'hello' => 'sub'}]}, 'bar' => [1, 2]}`, v.String())
+	})
+}
+
+func TestUnmarshalWithPositions(t *testing.T) {
+	pcore.Do(func(c px.Context) {
+		v := yaml.UnmarshalWithPositions(c, []byte(text))
+		require.Equal(t, `{'foo' => {'bar' => [1, 2, {'hello' => 'sub'}]}, 'bar' => [1, 2]}`, v.String())
+		bar, ok := v.Value.(px.OrderedMap).Get4(`bar`)
+		require.True(t, ok)
+		barPos, ok := bar.(*yaml.Value)
+		require.True(t, ok)
+		require.Equal(t, 4, barPos.Line)
+		require.Equal(t, 3, barPos.Column)
 	})
 }


### PR DESCRIPTION
The yaml.v3 is a much improved parser that produces nodes with line
number information which opens up for much more precise errors in
both the Lyra yaml workflows and Hiera.