### PR TITLE
Use common key type when reflecting type of hash

### DIFF
--- a/types/hashtype.go
+++ b/types/hashtype.go
@@ -337,6 +337,7 @@ func (t *HashType) ReflectType(c px.Context) (reflect.Type, bool) {
 		if vt, ok := ReflectType(c, t.valueType); ok {
 			return reflect.MapOf(kt, vt), true
 		}
+		return reflect.MapOf(kt, reflect.TypeOf((*interface{})(nil)).Elem()), true
 	}
 	return nil, false
 }

--- a/types/lexer.go
+++ b/types/lexer.go
@@ -241,7 +241,7 @@ func consumeNumber(sr *utils.StringReader, start rune, buf *bytes.Buffer, t toke
 		r := sr.Peek()
 		switch r {
 		case 0:
-			return 0
+			return t
 		case '0':
 			sr.Next()
 			buf.WriteRune(r)

--- a/types/parser_test.go
+++ b/types/parser_test.go
@@ -18,6 +18,13 @@ func ExampleParse_qName() {
 	// Output: DeferredType(Foo::Bar)
 }
 
+func ExampleParse_int() {
+	t := types.Parse(`23`)
+	t.ToString(os.Stdout, px.PrettyExpanded, nil)
+	fmt.Println()
+	// Output: 23
+}
+
 func ExampleParse_entry() {
 	const src = `# This is scanned code.
     constants => {


### PR DESCRIPTION
Before this commit, a hash like { x => 'a', y => 0 } was reflected into
the type map[interface{}]interface{}. This was caused by the logic failing
to reflect a common type of the value (string and int) and then used the
most generic types as a fallback. This commit ensures that the common key
type is used even if no common value type can be found so that reflected
type of the sample hash instead is map[string]interface{}.