### PR TITLE
Enable inclusion of Context parameter on go-reflected methods

### DIFF
--- a/px/reflector.go
+++ b/px/reflector.go
@@ -1,6 +1,7 @@
 package px
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/lyraproj/semver/semver"
@@ -123,3 +124,5 @@ type Reflector interface {
 	// Methods returns all methods of the given reflected type or an empty slice if no methods exists.
 	Methods(ptr reflect.Type) []reflect.Method
 }
+
+var ContextType = reflect.TypeOf((*context.Context)(nil)).Elem()

--- a/px/types.go
+++ b/px/types.go
@@ -166,6 +166,10 @@ type (
 		// ReturnsError returns true if the underlying method returns an error instance in case of
 		// failure. Such errors must be converted to panics by the caller
 		ReturnsError() bool
+
+		// TakesContext returns true if the first argument of the actual Go function
+		// is a context.Context
+		TakesContext() bool
 	}
 
 	AttributesInfo interface {


### PR DESCRIPTION
This commit makes the Reflector recognize methods where the first
parameter is assignable to context.Context (px.Context is assignable).
Subsequent calls to such methods will automatically pass the callers
context. The context parameter is otherwise invisible and will not be
included in the pcore Method declarations.

Closes lyraproj/lyra#318