### PR TITLE
Refactor to StringHash and rename pximpl package

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"context"

--- a/internal/equality.go
+++ b/internal/equality.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"fmt"

--- a/internal/function.go
+++ b/internal/function.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"fmt"

--- a/internal/implementationregistry.go
+++ b/internal/implementationregistry.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"reflect"

--- a/internal/parameter.go
+++ b/internal/parameter.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"io"

--- a/internal/pcore_test.go
+++ b/internal/pcore_test.go
@@ -1,4 +1,4 @@
-package pximpl_test
+package internal_test
 
 import (
 	"testing"

--- a/internal/runtime.go
+++ b/internal/runtime.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"context"

--- a/internal/setting.go
+++ b/internal/setting.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"fmt"

--- a/internal/typemismatchdescriber.go
+++ b/internal/typemismatchdescriber.go
@@ -1,4 +1,4 @@
-package pximpl
+package internal
 
 import (
 	"bytes"

--- a/pcore/entrypoint.go
+++ b/pcore/entrypoint.go
@@ -3,82 +3,82 @@ package pcore
 import (
 	"context"
 
+	"github.com/lyraproj/pcore/internal"
 	"github.com/lyraproj/pcore/px"
-	"github.com/lyraproj/pcore/pximpl"
 )
 
 // DefineSetting defines a new setting with a given valueType and default
 // value.
 func DefineSetting(key string, valueType px.Type, dflt px.Value) {
-	pximpl.InitializeRuntime().DefineSetting(key, valueType, dflt)
+	internal.InitializeRuntime().DefineSetting(key, valueType, dflt)
 }
 
 // Do executes a given function with an initialized Context instance.
 //
 // The Context will be parented by the Go context returned by context.Background()
 func Do(f func(c px.Context)) {
-	pximpl.InitializeRuntime().Do(f)
+	internal.InitializeRuntime().Do(f)
 }
 
 // DoWithParent executes a given function with an initialized Context instance.
 //
 // The context will be parented by the given Go context
 func DoWithParent(parentCtx context.Context, actor func(px.Context)) {
-	pximpl.InitializeRuntime().DoWithParent(parentCtx, actor)
+	internal.InitializeRuntime().DoWithParent(parentCtx, actor)
 }
 
 // EnvironmentLoader returns the loader that finds things declared
 // in the environment and its modules. This loader is parented
 // by the SystemLoader
 func EnvironmentLoader() px.Loader {
-	return pximpl.InitializeRuntime().EnvironmentLoader()
+	return internal.InitializeRuntime().EnvironmentLoader()
 }
 
 // Get returns a setting or calls the given defaultProducer
 // function if the setting does not exist
 func Get(key string, defaultProducer px.Producer) px.Value {
-	return pximpl.InitializeRuntime().Get(key, defaultProducer)
+	return internal.InitializeRuntime().Get(key, defaultProducer)
 }
 
 // Loader returns a loader for module.
 func Loader(key string) px.Loader {
-	return pximpl.InitializeRuntime().Loader(key)
+	return internal.InitializeRuntime().Loader(key)
 }
 
 func NewContext(loader px.Loader, logger px.Logger) px.Context {
-	return pximpl.NewContext(loader, logger)
+	return internal.NewContext(loader, logger)
 }
 
 // Logger returns the logger that this instance was created with
 func Logger() px.Logger {
-	return pximpl.InitializeRuntime().Logger()
+	return internal.InitializeRuntime().Logger()
 }
 
 // Reset clears all settings and loaders, except the static loader
 func Reset() {
-	pximpl.InitializeRuntime().Reset()
+	internal.InitializeRuntime().Reset()
 }
 
 // RootContext returns a new Context that is parented by the context.Background()
 // and is initialized with a loader that is parented by the EnvironmentLoader.
 func RootContext() px.Context {
-	return pximpl.InitializeRuntime().RootContext()
+	return internal.InitializeRuntime().RootContext()
 }
 
 // Set changes a setting
 func Set(key string, value px.Value) {
-	pximpl.InitializeRuntime().Set(key, value)
+	internal.InitializeRuntime().Set(key, value)
 }
 
 // SetLogger changes the logger
 func SetLogger(logger px.Logger) {
-	pximpl.InitializeRuntime().SetLogger(logger)
+	internal.InitializeRuntime().SetLogger(logger)
 }
 
 // SystemLoader returns the loader that finds all built-ins. It's parented
 // by a static loader.
 func SystemLoader() px.Loader {
-	return pximpl.InitializeRuntime().SystemLoader()
+	return internal.InitializeRuntime().SystemLoader()
 }
 
 // Try executes a given function with an initialized Context instance. If an error occurs,
@@ -87,7 +87,7 @@ func SystemLoader() px.Loader {
 //
 // The Context will be parented by the Go context returned by context.Background()
 func Try(actor func(px.Context) error) (err error) {
-	return pximpl.InitializeRuntime().Try(actor)
+	return internal.InitializeRuntime().Try(actor)
 }
 
 // TryWithParent executes a given function with an initialized Context instance.  If an error occurs,
@@ -96,9 +96,9 @@ func Try(actor func(px.Context) error) (err error) {
 //
 // The context will be parented by the given Go context
 func TryWithParent(parentCtx context.Context, actor func(px.Context) error) (err error) {
-	return pximpl.InitializeRuntime().TryWithParent(parentCtx, actor)
+	return internal.InitializeRuntime().TryWithParent(parentCtx, actor)
 }
 
 func WithParent(parent context.Context, loader px.Loader, logger px.Logger, ir px.ImplementationRegistry) px.Context {
-	return pximpl.WithParent(parent, loader, logger, ir)
+	return internal.WithParent(parent, loader, logger, ir)
 }

--- a/types/annotatable.go
+++ b/types/annotatable.go
@@ -47,7 +47,7 @@ func (a *annotatable) initialize(initHash *Hash) {
 	a.annotations = hashArg(initHash, keyAnnotations)
 }
 
-func (a *annotatable) initHash() *hash.StringHash {
+func (a *annotatable) initHash() hash.StringHash {
 	h := hash.NewStringHash(5)
 	if a.annotations.Len() > 0 {
 		h.Put(keyAnnotations, a.annotations)

--- a/types/annotatedmember.go
+++ b/types/annotatedmember.go
@@ -56,7 +56,7 @@ func (a *annotatedMember) Override() bool {
 	return a.override
 }
 
-func (a *annotatedMember) initHash() *hash.StringHash {
+func (a *annotatedMember) initHash() hash.StringHash {
 	h := a.annotatable.initHash()
 	h.Put(keyType, a.typ)
 	if a.final {
@@ -74,14 +74,13 @@ func (a *annotatedMember) Final() bool {
 
 // Checks if the this _member_ overrides an inherited member, and if so, that this member is declared with
 // override = true and that the inherited member accepts to be overridden by this member.
-func assertOverride(a px.AnnotatedMember, parentMembers *hash.StringHash) {
-	parentMember, _ := parentMembers.Get(a.Name(), nil).(px.AnnotatedMember)
-	if parentMember == nil {
+func assertOverride(a px.AnnotatedMember, parentMembers hash.StringHash) {
+	if parentMember, ok := parentMembers.Get(a.Name()); ok {
+		assertCanBeOverridden(parentMember.(px.AnnotatedMember), a)
+	} else {
 		if a.Override() {
 			panic(px.Error(px.OverriddenNotFound, issue.H{`label`: a.Label(), `feature_type`: a.FeatureType()}))
 		}
-	} else {
-		assertCanBeOverridden(parentMember, a)
 	}
 }
 

--- a/types/attribute.go
+++ b/types/attribute.go
@@ -113,7 +113,7 @@ func (a *attribute) HasValue() bool {
 	return a.value != nil
 }
 
-func (a *attribute) initHash() *hash.StringHash {
+func (a *attribute) initHash() hash.StringHash {
 	h := a.annotatedMember.initHash()
 	if a.kind != defaultKind {
 		h.Put(keyKind, stringValue(string(a.kind)))

--- a/types/hashtype.go
+++ b/types/hashtype.go
@@ -655,7 +655,7 @@ func sortedMap(hvEntries []*HashEntry) *Hash {
 	return &Hash{entries: hvEntries}
 }
 
-func WrapStringPValue(hash *hash.StringHash) *Hash {
+func WrapStringPValue(hash hash.StringHash) *Hash {
 	hvEntries := make([]*HashEntry, hash.Len())
 	i := 0
 	hash.EachPair(func(k string, v interface{}) {

--- a/types/typeparameter.go
+++ b/types/typeparameter.go
@@ -14,10 +14,10 @@ var TypeTypeParameter = NewStructType([]*StructElement{
 	NewStructElement(newOptionalType3(keyAnnotations), typeAnnotations),
 })
 
-func (t *typeParameter) initHash() *hash.StringHash {
+func (t *typeParameter) initHash() hash.StringHash {
 	h := t.attribute.initHash()
-	h.Put(keyType, h.Get(keyType, nil).(*TypeType).PType())
-	if v, ok := h.Get3(keyValue); ok && v.(px.Value).Equals(undef, nil) {
+	h.Put(keyType, h.GetOrDefault(keyType, nil).(*TypeType).PType())
+	if v, ok := h.Get(keyValue); ok && v.(px.Value).Equals(undef, nil) {
 		h.Delete(keyValue)
 	}
 	return h

--- a/types/typeset.go
+++ b/types/typeset.go
@@ -100,7 +100,7 @@ func newTypeSetReference(t *typeSet, ref *Hash) *typeSetReference {
 	return r
 }
 
-func (r *typeSetReference) initHash() *hash.StringHash {
+func (r *typeSetReference) initHash() hash.StringHash {
 	h := r.annotatable.initHash()
 	if r.nameAuthority != r.owner.nameAuthority {
 		h.Put(KeyNameAuthority, stringValue(string(r.nameAuthority)))
@@ -564,7 +564,7 @@ func (t *typeSet) basicTypeToString(b io.Writer, f px.Format, s px.FormatContext
 	utils.WriteString(b, "}]")
 }
 
-func (t *typeSet) initHash() *hash.StringHash {
+func (t *typeSet) initHash() hash.StringHash {
 	h := t.annotatable.initHash()
 	if t.pcoreURI != `` {
 		h.Put(px.KeyPcoreUri, WrapURI2(string(t.pcoreURI)))
@@ -650,7 +650,7 @@ func (t *typeSet) resolveDeferred(c px.Context, lh px.OrderedMap) *Hash {
 
 	result := WrapHash(entries)
 	nameAuth := t.resolveNameAuthority(result, c, nil)
-	if !types.IsEmpty() {
+	if !types.Empty() {
 		es := make([]*HashEntry, 0, types.Len())
 		types.EachPair(func(typeName string, value interface{}) {
 			fullName := fmt.Sprintf(`%s::%s`, t.name, typeName)


### PR DESCRIPTION
This commit changes the hash.StringHash into an interface with
a private implementation and also renames the package pximpl to
internal to avoid external references to it.