### PR TITLE
Create InstanceHash method on the ObjectType

### DIFF
--- a/internal/parameter.go
+++ b/internal/parameter.go
@@ -31,6 +31,9 @@ func (p *parameter) Name() string {
 }
 
 func (p *parameter) Value() px.Value {
+	if p.value == nil {
+		return px.Undef
+	}
 	return p.value
 }
 
@@ -59,22 +62,10 @@ func (p *parameter) Get(key string) (value px.Value, ok bool) {
 }
 
 func (p *parameter) InitHash() px.OrderedMap {
-	es := make([]*types.HashEntry, 0, 3)
-	es = append(es, types.WrapHashEntry2(`name`, types.WrapString(p.name)))
-	es = append(es, types.WrapHashEntry2(`type`, p.typ))
-	if p.value != nil {
-		es = append(es, types.WrapHashEntry2(`value`, p.value))
-	}
-	if p.value == px.Undef {
-		es = append(es, types.WrapHashEntry2(`has_value`, types.BooleanTrue))
-	}
-	if p.captures {
-		es = append(es, types.WrapHashEntry2(`captures_rest`, types.BooleanTrue))
-	}
-	return types.WrapHash(es)
+	return ParameterMetaType.InstanceHash(p)
 }
 
-var ParameterMetaType px.Type
+var ParameterMetaType px.ObjectType
 
 func (p *parameter) Equals(other interface{}, guard px.Guard) bool {
 	return p == other

--- a/px/types.go
+++ b/px/types.go
@@ -198,6 +198,9 @@ type (
 		//
 		GoType() reflect.Type
 
+		// InstanceHash returns the InitHash for the given instance. The instance must be of this type
+		InstanceHash(o Value) OrderedMap
+
 		// IsInterface returns true for non parameterized types that contains only methods
 		IsInterface() bool
 

--- a/types/deferred.go
+++ b/types/deferred.go
@@ -106,7 +106,7 @@ func (e *deferred) Get(key string) (value px.Value, ok bool) {
 }
 
 func (e *deferred) InitHash() px.OrderedMap {
-	return WrapHash([]*HashEntry{WrapHashEntry2(`name`, stringValue(e.name)), WrapHashEntry2(`arguments`, e.arguments)})
+	return DeferredMetaType.InstanceHash(e)
 }
 
 func (e *deferred) Resolve(c px.Context, scope px.Keyed) px.Value {

--- a/types/objecttype.go
+++ b/types/objecttype.go
@@ -623,6 +623,33 @@ func (t *objectType) InitHash() px.OrderedMap {
 	return WrapStringPValue(t.initHash(true))
 }
 
+func (t *objectType) InstanceHash(o px.Value) px.OrderedMap {
+	if pu, ok := o.(px.PuppetObject); ok {
+		pi := t.AttributesInfo()
+		at := pi.Attributes()
+		nc := len(at)
+		if nc == 0 {
+			return px.EmptyMap
+		}
+
+		entries := make([]*HashEntry, 0, nc)
+		for _, attr := range pi.Attributes() {
+			switch attr.Kind() {
+			case constant, derived:
+				continue
+			}
+			if v, ok := pu.Get(attr.Name()); ok {
+				if attr.HasValue() && attr.Value().Equals(v, nil) {
+					continue
+				}
+				entries = append(entries, WrapHashEntry2(attr.Name(), v))
+			}
+		}
+		return WrapHash(entries)
+	}
+	return emptyMap
+}
+
 func (t *objectType) IsInterface() bool {
 	return t.isInterface
 }

--- a/types/objecttypeextension.go
+++ b/types/objecttypeextension.go
@@ -79,6 +79,10 @@ func (te *objectTypeExtension) Implements(ifd px.ObjectType, g px.Guard) bool {
 	return te.baseType.Implements(ifd, g)
 }
 
+func (te *objectTypeExtension) InstanceHash(o px.Value) px.OrderedMap {
+	return te.baseType.InstanceHash(o)
+}
+
 func (te *objectTypeExtension) IsInterface() bool {
 	return false
 }

--- a/types/typedname.go
+++ b/types/typedname.go
@@ -17,7 +17,7 @@ type typedName struct {
 	parts     []string
 }
 
-var TypedNameMetaType px.Type
+var TypedNameMetaType px.ObjectType
 
 func init() {
 	TypedNameMetaType = newObjectType(`TypedName`, `{
@@ -105,13 +105,7 @@ func (t *typedName) Get(key string) (value px.Value, ok bool) {
 }
 
 func (t *typedName) InitHash() px.OrderedMap {
-	es := make([]*HashEntry, 0, 3)
-	es = append(es, WrapHashEntry2(`namespace`, stringValue(string(t.Namespace()))))
-	es = append(es, WrapHashEntry2(`name`, stringValue(t.Name())))
-	if t.authority != px.RuntimeNameAuthority {
-		es = append(es, WrapHashEntry2(`authority`, WrapURI2(string(t.authority))))
-	}
-	return WrapHash(es)
+	return TypedNameMetaType.InstanceHash(t)
 }
 
 func NewTypedName(namespace px.Namespace, name string) px.TypedName {


### PR DESCRIPTION
Several implementations of PuppetObject have a hard-coded InitHash
method. This is unnecessary because a PuppetObject is always an instance
of an ObjectType and the ObjectType has all information needed to create
such a hash dynamically.

This commit adds the ObjectType.InstanceHash() method and replaces the
body of all hard-coded InitHash methods with a call to that method.